### PR TITLE
Bump Slurm to latest secure minor version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ LABEL org.label-schema.vcs-url="https://github.com/giovtorres/slurm-docker-clust
      org.label-schema.description="Slurm Docker cluster on CentOS 7"
 
 ENV SLURM_VERSION 17.02.9
-ENV SLURM_DOWNLOAD_MD5 64009c1ed120b9ce5d79424dca743a06
+ENV SLURM_DOWNLOAD_MD5 6bd0b38e6bf08f3426a7dd1e663a2e3c
 ENV SLURM_DOWNLOAD_URL https://www.schedmd.com/downloads/latest/slurm-"$SLURM_VERSION".tar.bz2
 
 ENV GOSU_VERSION 1.10

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ LABEL org.label-schema.vcs-url="https://github.com/giovtorres/slurm-docker-clust
      org.label-schema.name="slurm-docker-cluster" \
      org.label-schema.description="Slurm Docker cluster on CentOS 7"
 
-ENV SLURM_VERSION 17.02.7
+ENV SLURM_VERSION 17.02.9
 ENV SLURM_DOWNLOAD_MD5 64009c1ed120b9ce5d79424dca743a06
 ENV SLURM_DOWNLOAD_URL https://www.schedmd.com/downloads/latest/slurm-"$SLURM_VERSION".tar.bz2
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The compose file will create the following named volumes:
 Build the image locally:
 
 ```console
-$ docker build -t slurm-docker-cluster:17.02.7 .
+$ docker build -t slurm-docker-cluster:17.02.9 .
 ```
 
 ## Starting the Cluster

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
       - var_lib_mysql:/var/lib/mysql
 
   slurmdbd:
-    image: slurm-docker-cluster:17.02.7
+    image: slurm-docker-cluster:17.02.9
     command: ["slurmdbd"]
     container_name: slurmdbd
     hostname: slurmdbd
@@ -28,7 +28,7 @@ services:
       - mysql
 
   slurmctld:
-    image: slurm-docker-cluster:17.02.7
+    image: slurm-docker-cluster:17.02.9
     command: ["slurmctld"]
     container_name: slurmctld
     hostname: slurmctld
@@ -43,7 +43,7 @@ services:
       - "slurmdbd"
 
   c1:
-    image: slurm-docker-cluster:17.02.7
+    image: slurm-docker-cluster:17.02.9
     command: ["slurmd"]
     hostname: c1
     container_name: c1
@@ -58,7 +58,7 @@ services:
       - "slurmctld"
 
   c2:
-    image: slurm-docker-cluster:17.02.7
+    image: slurm-docker-cluster:17.02.9
     command: ["slurmd"]
     hostname: c2
     container_name: c2


### PR DESCRIPTION
The container build fails with 17.02.7 because this version has been removed from the download server due to a security vulnerability.  Version has been updated to 17.02.9.