### PR TITLE
Fixed pip3 to pip3.4 in dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,7 @@ RUN yum makecache fast \
     && rm -rf /var/cache/yum
 
 RUN pip install Cython nose \
-    && pip3 install Cython nose
+    && pip3.4 install Cython nose
 
 RUN set -x \
     && wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-amd64" \


### PR DESCRIPTION
The docker image wouldn't build with pip3, so I changed it to pip3.4 and then it worked.