### PR TITLE
Issue 16: more slurm versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM centos:7
+FROM rockylinux:8
 
 LABEL org.opencontainers.image.source="https://github.com/giovtorres/slurm-docker-cluster" \
       org.opencontainers.image.title="slurm-docker-cluster" \
-      org.opencontainers.image.description="Slurm Docker cluster on CentOS 7" \
+      org.opencontainers.image.description="Slurm Docker cluster on Rocky Linux 8" \
       org.label-schema.docker.cmd="docker-compose up -d" \
       maintainer="Giovanni Torres"
 
@@ -10,9 +10,10 @@ ARG SLURM_TAG=slurm-19-05-1-2
 ARG GOSU_VERSION=1.11
 
 RUN set -ex \
-    && yum makecache fast \
+    && yum makecache \
     && yum -y update \
-    && yum -y install epel-release \
+    && yum -y install dnf-plugins-core \
+    && yum config-manager --set-enabled powertools \
     && yum -y install \
        wget \
        bzip2 \
@@ -24,11 +25,9 @@ RUN set -ex \
        make \
        munge \
        munge-devel \
-       python-devel \
-       python-pip \
-       python34 \
-       python34-devel \
-       python34-pip \
+       python3-devel \
+       python3-pip \
+       python3 \
        mariadb-server \
        mariadb-devel \
        psmisc \
@@ -36,10 +35,10 @@ RUN set -ex \
        vim-enhanced \
     && yum clean all \
     && rm -rf /var/cache/yum
-    
-RUN ln -s /usr/bin/python3.4 /usr/bin/python3
 
-RUN pip install Cython nose && pip3.4 install Cython nose
+RUN alternatives --set python /usr/bin/python3
+
+RUN pip3 install Cython nose
 
 RUN set -ex \
     && wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-amd64" \
@@ -64,8 +63,8 @@ RUN set -x \
     && install -D -m644 contribs/slurm_completion_help/slurm_completion.sh /etc/profile.d/slurm_completion.sh \
     && popd \
     && rm -rf slurm \
-    && groupadd -r --gid=995 slurm \
-    && useradd -r -g slurm --uid=995 slurm \
+    && groupadd -r --gid=990 slurm \
+    && useradd -r -g slurm --uid=990 slurm \
     && mkdir /etc/sysconfig/slurm \
         /var/spool/slurmd \
         /var/run/slurmd \
@@ -87,6 +86,10 @@ RUN set -x \
 
 COPY slurm.conf /etc/slurm/slurm.conf
 COPY slurmdbd.conf /etc/slurm/slurmdbd.conf
+RUN set -x \
+    && chown slurm:slurm /etc/slurm/slurmdbd.conf \
+    && chmod 600 /etc/slurm/slurmdbd.conf
+
 
 COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ LABEL org.opencontainers.image.source="https://github.com/giovtorres/slurm-docke
       org.label-schema.docker.cmd="docker-compose up -d" \
       maintainer="Giovanni Torres"
 
-ARG SLURM_TAG=slurm-19-05-1-2
+ARG SLURM_TAG=slurm-21-08-6-1
 ARG GOSU_VERSION=1.11
 
 RUN set -ex \

--- a/Dockerfile
+++ b/Dockerfile
@@ -51,9 +51,8 @@ RUN set -ex \
     && gosu nobody true
 
 RUN set -x \
-    && git clone https://github.com/SchedMD/slurm.git \
+    && git clone -b ${SLURM_TAG} --single-branch --depth=1 https://github.com/SchedMD/slurm.git \
     && pushd slurm \
-    && git checkout tags/$SLURM_TAG \
     && ./configure --enable-debug --prefix=/usr --sysconfdir=/etc/slurm \
         --with-mysql_config=/usr/bin  --libdir=/usr/lib64 \
     && make install \

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The compose file will create the following named volumes:
 Build the image locally:
 
 ```console
-docker build -t slurm-docker-cluster:19.05.1 .
+docker build -t slurm-docker-cluster:21.08.6 .
 ```
 
 Build a different version of Slurm using Docker build args and the Slurm Git
@@ -37,9 +37,11 @@ tag:
 docker build --build-arg SLURM_TAG="slurm-19-05-2-1" -t slurm-docker-cluster:19.05.2 .
 ```
 
-> Note: You will need to update the container image version in
-> [docker-compose.yml](docker-compose.yml).
+Or equivalently using `docker-compose`:
 
+```console
+SLURM_TAG=slurm-19-05-2-1 IMAGE_TAG=19.05.2 docker_compose build
+```
 
 
 ## Starting the Cluster
@@ -47,7 +49,7 @@ docker build --build-arg SLURM_TAG="slurm-19-05-2-1" -t slurm-docker-cluster:19.
 Run `docker-compose` to instantiate the cluster:
 
 ```console
-docker-compose up -d
+IMAGE_TAG=19.05.2 docker-compose up -d
 ```
 
 ## Register the Cluster with SlurmDBD

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,11 @@ services:
       - var_lib_mysql:/var/lib/mysql
 
   slurmdbd:
-    image: slurm-docker-cluster:19.05.1
+    image: slurm-docker-cluster:${IMAGE_TAG:-21.08}
+    build:
+      context: .
+      args:
+        SLURM_TAG: ${SLURM_TAG:-slurm-21-08-6-1}
     command: ["slurmdbd"]
     container_name: slurmdbd
     hostname: slurmdbd
@@ -28,7 +32,7 @@ services:
       - mysql
 
   slurmctld:
-    image: slurm-docker-cluster:19.05.1
+    image: slurm-docker-cluster:${IMAGE_TAG:-21.08}
     command: ["slurmctld"]
     container_name: slurmctld
     hostname: slurmctld
@@ -43,7 +47,7 @@ services:
       - "slurmdbd"
 
   c1:
-    image: slurm-docker-cluster:19.05.1
+    image: slurm-docker-cluster:${IMAGE_TAG:-21.08}
     command: ["slurmd"]
     hostname: c1
     container_name: c1
@@ -58,7 +62,7 @@ services:
       - "slurmctld"
 
   c2:
-    image: slurm-docker-cluster:19.05.1
+    image: slurm-docker-cluster:${IMAGE_TAG:-21.08}
     command: ["slurmd"]
     hostname: c2
     container_name: c2

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -36,7 +36,11 @@ then
     echo "-- slurmdbd is now active ..."
 
     echo "---> Starting the Slurm Controller Daemon (slurmctld) ..."
-    exec gosu slurm /usr/sbin/slurmctld -Dvvv
+    if /usr/sbin/slurmctld -V | grep -q '17.02' ; then
+        exec gosu slurm /usr/sbin/slurmctld -Dvvv
+    else
+        exec gosu slurm /usr/sbin/slurmctld -i -Dvvv
+    fi
 fi
 
 if [ "$1" = "slurmd" ]

--- a/slurm.conf
+++ b/slurm.conf
@@ -23,7 +23,7 @@ SlurmctldPidFile=/var/run/slurmd/slurmctld.pid
 SlurmdPidFile=/var/run/slurmd/slurmd.pid
 ProctrackType=proctrack/linuxproc
 #PluginDir=
-CacheGroups=0
+#CacheGroups=0
 #FirstJobId=
 ReturnToService=0
 #MaxJobCount=
@@ -83,7 +83,7 @@ JobAcctGatherFrequency=30
 AccountingStorageType=accounting_storage/slurmdbd
 AccountingStorageHost=slurmdbd
 AccountingStoragePort=6819
-AccountingStorageLoc=slurm_acct_db
+#AccountingStorageLoc=slurm_acct_db
 #AccountingStoragePass=
 #AccountingStorageUser=
 #

--- a/slurmdbd.conf
+++ b/slurmdbd.conf
@@ -34,4 +34,4 @@ StorageType=accounting_storage/mysql
 StorageHost=mysql
 StorageUser=slurm
 StoragePass=password
-StorageLoc=slurm_acct_db
+#StorageLoc=slurm_acct_db


### PR DESCRIPTION
Hi, and thanks for making and sharing this handy set-up. It's been very useful!

I've been doing some work on https://github.com/vecma-project/QCG-PilotJob, which uses an old fork of slurm-docker-cluster for its test setup. I wanted to test a broad range of Slurm versions, so I made some upgrades, and I figured I'd contribute them back here as well.

This PR upgrades to Rocky Linux 8, which seems to be the natural successor to the old CentOS. (I'm a Debian guy, so I hope I picked the right one.) It also fixes some issues I ran into while compiling different versions of Slurm. For me, this now works with the latest versions of 17.02, 17.11, 18.08, 19.05, 20.02, 20.11 and 21.08.

The final commit makes the Slurm version configurable in docker-compose.yaml, but that does mean that you always have to set it, so it **may break things** for people who have scripts calling docker-compose. You may want to cherry-pick the others rather than merging this wholesale.

This fixes #16 I think, CentOS 8 no longer being available.