### PR TITLE
Using mariadb instead of mysql

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "2.2"
 
 services:
   mysql:
-    image: mysql:5.7
+    image: mariadb:10.10
     hostname: mysql
     container_name: mysql
     environment:


### PR DESCRIPTION
The mysql5.7 container is incompatible with M1 Macs. Switching to mariadb fixes the issue, and should behave roughly the same.

Resolves #26 