### PR TITLE
add json support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,8 @@ RUN set -ex \
        psmisc \
        bash-completion \
        vim-enhanced \
+       http-parser-devel \
+       json-c-devel \
     && yum clean all \
     && rm -rf /var/cache/yum
 


### PR DESCRIPTION
This install the json libraries and headers required to have json support in Slurm. Without it running `sacct --json` throws an `sacct: fatal: Unable to find plugin: serializer/json` error.

Test plan:

```
docker build -t slurm-docker-cluster:21.08.6 .
IMAGE_TAG=21.08.6 docker-compose up -d
docker exec -it c1 sacct --json
```