### PR TITLE
Remove configuration from image

### DIFF
--- a/.github/workflows/build-containers.yml
+++ b/.github/workflows/build-containers.yml
@@ -3,7 +3,7 @@ on:
   push:
     paths:
       - .github/workflows/build-containers.yml
-      - ./Dockerfile
+      - Dockerfile
     workflow_dispatch:
 
 jobs:

--- a/.github/workflows/build-containers.yml
+++ b/.github/workflows/build-containers.yml
@@ -3,6 +3,7 @@ on:
   push:
     paths:
       - .github/workflows/**
+	workflow_dispatch:
 jobs:
   build_push_api:
     name: Build and push Docker image

--- a/.github/workflows/build-containers.yml
+++ b/.github/workflows/build-containers.yml
@@ -1,0 +1,72 @@
+name: Build and push Docker image
+on:
+  push:
+    paths:
+      - images/**
+      - .github/workflows/**
+jobs:
+  build_push_api:
+    name: Build and push Docker image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Set up Docker layer caching
+        uses: actions/cache@v3
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install apptainer
+        run: |
+          sudo apt install -y software-properties-common
+          sudo add-apt-repository -y ppa:apptainer/ppa
+          sudo apt update
+          sudo apt install -y apptainer
+
+      - name: Calculate metadata for image
+        id: image-meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ghcr.io/${{ github.repository }}
+          # Produce the branch name or tag and the SHA as tags
+          tags: |
+            type=ref,event=branch
+            type=ref,event=tag
+            type=sha,prefix=
+
+      - name: Build and push image
+        uses: docker/build-push-action@v4
+        with:
+          provenance: false
+          context: ./images/
+          push: true
+          tags: ${{ steps.image-meta.outputs.tags }}
+          labels: ${{ steps.image-meta.outputs.labels }}
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
+
+      - name: Test image by running help
+        run: singularity exec docker://${{ fromJSON(steps.image-meta.outputs.json).tags[1] }} /io500 -h
+
+      # Temp fix
+      # https://github.com/docker/build-push-action/issues/252
+      # https://github.com/moby/buildkit/issues/1896
+      # https://github.com/docker/buildx/pull/535
+      - name: Move cache
+        run: |
+          rm -rf /tmp/.buildx-cache
+          mv /tmp/.buildx-cache-new /tmp/.buildx-cache

--- a/.github/workflows/build-containers.yml
+++ b/.github/workflows/build-containers.yml
@@ -3,7 +3,8 @@ on:
   push:
     paths:
       - .github/workflows/**
-	workflow_dispatch:
+    workflow_dispatch:
+
 jobs:
   build_push_api:
     name: Build and push Docker image

--- a/.github/workflows/build-containers.yml
+++ b/.github/workflows/build-containers.yml
@@ -52,7 +52,7 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           provenance: false
-          context: ./images/
+          #context: ./images/
           push: true
           tags: ${{ steps.image-meta.outputs.tags }}
           labels: ${{ steps.image-meta.outputs.labels }}

--- a/.github/workflows/build-containers.yml
+++ b/.github/workflows/build-containers.yml
@@ -59,11 +59,11 @@ jobs:
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
+      - name: Verify push to GHCR
+        run: docker inspect ${{ fromJSON(steps.image-meta.outputs.json).tags[1] }}
+
       #- name: Test image by running help
       #  run: singularity exec docker://${{ fromJSON(steps.image-meta.outputs.json).tags[1] }} /io500 -h
-
-			- name: Verify has been posted successfully
-			  run: docker inspect ${{ fromJSON(steps.image-meta.outputs.json).tags[1] }}
 
       # Temp fix
       # https://github.com/docker/build-push-action/issues/252

--- a/.github/workflows/build-containers.yml
+++ b/.github/workflows/build-containers.yml
@@ -3,7 +3,7 @@ on:
   push:
     paths:
       - .github/workflows/build-containers.yml
-			- ./Dockerfile
+      - ./Dockerfile
     workflow_dispatch:
 
 jobs:

--- a/.github/workflows/build-containers.yml
+++ b/.github/workflows/build-containers.yml
@@ -2,7 +2,8 @@ name: Build and push Docker image
 on:
   push:
     paths:
-      - .github/workflows/**
+      - .github/workflows/build-containers.yml
+			- ./Dockerfile
     workflow_dispatch:
 
 jobs:
@@ -30,13 +31,6 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Install apptainer
-        run: |
-          sudo apt install -y software-properties-common
-          sudo add-apt-repository -y ppa:apptainer/ppa
-          sudo apt update
-          sudo apt install -y apptainer
 
       - name: Calculate metadata for image
         id: image-meta

--- a/.github/workflows/build-containers.yml
+++ b/.github/workflows/build-containers.yml
@@ -63,7 +63,7 @@ jobs:
       #  run: singularity exec docker://${{ fromJSON(steps.image-meta.outputs.json).tags[1] }} /io500 -h
 
 			- name: Verify has been posted successfully
-			- run: docker inspect ${{ fromJSON(steps.image-meta.outputs.json).tags[1] }}
+			  run: docker inspect ${{ fromJSON(steps.image-meta.outputs.json).tags[1] }}
 
       # Temp fix
       # https://github.com/docker/build-push-action/issues/252

--- a/.github/workflows/build-containers.yml
+++ b/.github/workflows/build-containers.yml
@@ -2,7 +2,6 @@ name: Build and push Docker image
 on:
   push:
     paths:
-      - images/**
       - .github/workflows/**
 jobs:
   build_push_api:
@@ -59,8 +58,8 @@ jobs:
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-      - name: Verify push to GHCR
-        run: docker inspect ${{ fromJSON(steps.image-meta.outputs.json).tags[1] }}
+      #- name: Verify push to GHCR
+      #  run: docker inspect ${{ fromJSON(steps.image-meta.outputs.json).tags[1] }}
 
       #- name: Test image by running help
       #  run: singularity exec docker://${{ fromJSON(steps.image-meta.outputs.json).tags[1] }} /io500 -h

--- a/.github/workflows/build-containers.yml
+++ b/.github/workflows/build-containers.yml
@@ -59,8 +59,11 @@ jobs:
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-      - name: Test image by running help
-        run: singularity exec docker://${{ fromJSON(steps.image-meta.outputs.json).tags[1] }} /io500 -h
+      #- name: Test image by running help
+      #  run: singularity exec docker://${{ fromJSON(steps.image-meta.outputs.json).tags[1] }} /io500 -h
+
+			- name: Verify has been posted successfully
+			- run: docker inspect ${{ fromJSON(steps.image-meta.outputs.json).tags[1] }}
 
       # Temp fix
       # https://github.com/docker/build-push-action/issues/252

--- a/Dockerfile
+++ b/Dockerfile
@@ -62,8 +62,9 @@ RUN set -x \
     && popd \
     && rm -rf slurm \
     && groupadd -r --gid=990 slurm \
-    && useradd -r -g slurm --uid=990 slurm \
-    && mkdir /etc/sysconfig/slurm \
+    && useradd -r -g slurm --uid=990 slurm
+
+RUN mkdir /etc/sysconfig/slurm \
         /var/spool/slurmd \
         /var/run/slurmd \
         /var/run/slurmdbd \
@@ -81,17 +82,9 @@ RUN set -x \
         /var/lib/slurmd/qos_usage \
         /var/lib/slurmd/fed_mgr_state \
     && chown -R slurm:slurm /var/*/slurm* \
-    && chown -R slurm:slurm /etc/slurm \
-    && chmod -R 600 /etc/slurm \
     && /sbin/create-munge-key
 
-#COPY slurm.conf /etc/slurm/slurm.conf
-#COPY slurmdbd.conf /etc/slurm/slurmdbd.conf
-#RUN set -x \
-#    && chown slurm:slurm /etc/slurm/slurmdbd.conf \
-#    && chmod 600 /etc/slurm/slurmdbd.conf
-
-
+VOLUME /etc/slurm
 COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -85,11 +85,11 @@ RUN set -x \
     && chown -R slurm:slurm /var/*/slurm* \
     && /sbin/create-munge-key
 
-COPY slurm.conf /etc/slurm/slurm.conf
-COPY slurmdbd.conf /etc/slurm/slurmdbd.conf
-RUN set -x \
-    && chown slurm:slurm /etc/slurm/slurmdbd.conf \
-    && chmod 600 /etc/slurm/slurmdbd.conf
+#COPY slurm.conf /etc/slurm/slurm.conf
+#COPY slurmdbd.conf /etc/slurm/slurmdbd.conf
+#RUN set -x \
+#    && chown slurm:slurm /etc/slurm/slurmdbd.conf \
+#    && chmod 600 /etc/slurm/slurmdbd.conf
 
 
 COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -58,9 +58,6 @@ RUN set -x \
     && ./configure --enable-debug --prefix=/usr --sysconfdir=/etc/slurm \
         --with-mysql_config=/usr/bin  --libdir=/usr/lib64 \
     && make install \
-#    && install -D -m644 etc/cgroup.conf.example /etc/slurm/cgroup.conf.example \
-#    && install -D -m644 etc/slurm.conf.example /etc/slurm/slurm.conf.example \
-#    && install -D -m644 etc/slurmdbd.conf.example /etc/slurm/slurmdbd.conf.example \
     && install -D -m644 contribs/slurm_completion_help/slurm_completion.sh /etc/profile.d/slurm_completion.sh \
     && popd \
     && rm -rf slurm \
@@ -85,6 +82,7 @@ RUN set -x \
         /var/lib/slurmd/fed_mgr_state \
     && chown -R slurm:slurm /var/*/slurm* \
     && chown -R slurm:slurm /etc/slurm \
+    && chmod -R 600 /etc/slurm \
     && /sbin/create-munge-key
 
 #COPY slurm.conf /etc/slurm/slurm.conf

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
 FROM rockylinux:8
 
-LABEL org.opencontainers.image.source="https://github.com/giovtorres/slurm-docker-cluster" \
+LABEL org.opencontainers.image.source="https://github.com/stackhpc/slurm-docker-cluster" \
       org.opencontainers.image.title="slurm-docker-cluster" \
       org.opencontainers.image.description="Slurm Docker cluster on Rocky Linux 8" \
       org.label-schema.docker.cmd="docker-compose up -d" \
-      maintainer="Giovanni Torres"
+      maintainer="StackHPC"
 
-ARG SLURM_TAG=slurm-21-08-6-1
+ARG SLURM_TAG=slurm-23-02
 ARG GOSU_VERSION=1.11
 
 RUN set -ex \

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ LABEL org.opencontainers.image.source="https://github.com/stackhpc/slurm-docker-
       org.label-schema.docker.cmd="docker-compose up -d" \
       maintainer="StackHPC"
 
-ARG SLURM_TAG=slurm-23-02
+ARG SLURM_TAG=slurm-23.02
 ARG GOSU_VERSION=1.11
 
 RUN set -ex \

--- a/Dockerfile
+++ b/Dockerfile
@@ -58,9 +58,9 @@ RUN set -x \
     && ./configure --enable-debug --prefix=/usr --sysconfdir=/etc/slurm \
         --with-mysql_config=/usr/bin  --libdir=/usr/lib64 \
     && make install \
-    && install -D -m644 etc/cgroup.conf.example /etc/slurm/cgroup.conf.example \
-    && install -D -m644 etc/slurm.conf.example /etc/slurm/slurm.conf.example \
-    && install -D -m644 etc/slurmdbd.conf.example /etc/slurm/slurmdbd.conf.example \
+#    && install -D -m644 etc/cgroup.conf.example /etc/slurm/cgroup.conf.example \
+#    && install -D -m644 etc/slurm.conf.example /etc/slurm/slurm.conf.example \
+#    && install -D -m644 etc/slurmdbd.conf.example /etc/slurm/slurmdbd.conf.example \
     && install -D -m644 contribs/slurm_completion_help/slurm_completion.sh /etc/profile.d/slurm_completion.sh \
     && popd \
     && rm -rf slurm \
@@ -73,6 +73,7 @@ RUN set -x \
         /var/lib/slurmd \
         /var/log/slurm \
         /data \
+        /etc/slurm \
     && touch /var/lib/slurmd/node_state \
         /var/lib/slurmd/front_end_state \
         /var/lib/slurmd/job_state \
@@ -83,6 +84,7 @@ RUN set -x \
         /var/lib/slurmd/qos_usage \
         /var/lib/slurmd/fed_mgr_state \
     && chown -R slurm:slurm /var/*/slurm* \
+    && chown -R slurm:slurm /etc/slurm \
     && /sbin/create-munge-key
 
 #COPY slurm.conf /etc/slurm/slurm.conf

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,11 +14,11 @@ services:
       - var_lib_mysql:/var/lib/mysql
 
   slurmdbd:
-    image: slurm-docker-cluster:${IMAGE_TAG:-21.08}
+    image: slurm-docker-cluster:${IMAGE_TAG:-dbee501}
     build:
       context: .
       args:
-        SLURM_TAG: ${SLURM_TAG:-slurm-21-08-6-1}
+        SLURM_TAG: ${SLURM_TAG:-slurm-23.02}
     command: ["slurmdbd"]
     container_name: slurmdbd
     hostname: slurmdbd
@@ -32,7 +32,7 @@ services:
       - mysql
 
   slurmctld:
-    image: slurm-docker-cluster:${IMAGE_TAG:-21.08}
+    image: slurm-docker-cluster:${IMAGE_TAG:-dbee501}
     command: ["slurmctld"]
     container_name: slurmctld
     hostname: slurmctld
@@ -47,7 +47,7 @@ services:
       - "slurmdbd"
 
   c1:
-    image: slurm-docker-cluster:${IMAGE_TAG:-21.08}
+    image: slurm-docker-cluster:${IMAGE_TAG:-dbee501}
     command: ["slurmd"]
     hostname: c1
     container_name: c1
@@ -62,7 +62,7 @@ services:
       - "slurmctld"
 
   c2:
-    image: slurm-docker-cluster:${IMAGE_TAG:-21.08}
+    image: slurm-docker-cluster:${IMAGE_TAG:-dbee501}
     command: ["slurmd"]
     hostname: c2
     container_name: c2

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,7 @@ services:
       context: .
       args:
         SLURM_TAG: ${SLURM_TAG:-slurm-23.02}
+    #command: sh -c "set -x && chown slurm:slurm /etc/slurm/slurmdbd.conf && chmod 600 /etc/slurm/slurmdbd.conf && slurmdbd
     command: ["slurmdbd"]
     container_name: slurmdbd
     hostname: slurmdbd
@@ -26,6 +27,8 @@ services:
       - etc_munge:/etc/munge
       - etc_slurm:/etc/slurm
       - var_log_slurm:/var/log/slurm
+      - ./slurm.conf:/etc/slurm/slurm.conf
+      - ./slurmdbd.conf:/etc/slurm/slurmdbd.conf
     expose:
       - "6819"
     depends_on:
@@ -41,6 +44,8 @@ services:
       - etc_slurm:/etc/slurm
       - slurm_jobdir:/data
       - var_log_slurm:/var/log/slurm
+      - ./slurm.conf:/etc/slurm/slurm.conf
+      - ./slurmdbd.conf:/etc/slurm/slurmdbd.conf
     expose:
       - "6817"
     depends_on:
@@ -56,6 +61,8 @@ services:
       - etc_slurm:/etc/slurm
       - slurm_jobdir:/data
       - var_log_slurm:/var/log/slurm
+      - ./slurm.conf:/etc/slurm/slurm.conf
+      - ./slurmdbd.conf:/etc/slurm/slurmdbd.conf
     expose:
       - "6818"
     depends_on:
@@ -71,6 +78,8 @@ services:
       - etc_slurm:/etc/slurm
       - slurm_jobdir:/data
       - var_log_slurm:/var/log/slurm
+      - ./slurm.conf:/etc/slurm/slurm.conf
+      - ./slurmdbd.conf:/etc/slurm/slurmdbd.conf
     expose:
       - "6818"
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,13 +19,11 @@ services:
       context: .
       args:
         SLURM_TAG: ${SLURM_TAG:-slurm-23.02}
-    #command: sh -c "set -x && chown slurm:slurm /etc/slurm/slurmdbd.conf && chmod 600 /etc/slurm/slurmdbd.conf && slurmdbd
     command: ["slurmdbd"]
     container_name: slurmdbd
     hostname: slurmdbd
     volumes:
       - etc_munge:/etc/munge
-      - etc_slurm:/etc/slurm
       - var_log_slurm:/var/log/slurm
       - ./slurm.conf:/etc/slurm/slurm.conf
       - ./slurmdbd.conf:/etc/slurm/slurmdbd.conf
@@ -41,11 +39,9 @@ services:
     hostname: slurmctld
     volumes:
       - etc_munge:/etc/munge
-      - etc_slurm:/etc/slurm
       - slurm_jobdir:/data
       - var_log_slurm:/var/log/slurm
       - ./slurm.conf:/etc/slurm/slurm.conf
-      - ./slurmdbd.conf:/etc/slurm/slurmdbd.conf
     expose:
       - "6817"
     depends_on:
@@ -58,11 +54,9 @@ services:
     container_name: c1
     volumes:
       - etc_munge:/etc/munge
-      - etc_slurm:/etc/slurm
       - slurm_jobdir:/data
       - var_log_slurm:/var/log/slurm
       - ./slurm.conf:/etc/slurm/slurm.conf
-      - ./slurmdbd.conf:/etc/slurm/slurmdbd.conf
     expose:
       - "6818"
     depends_on:
@@ -75,11 +69,9 @@ services:
     container_name: c2
     volumes:
       - etc_munge:/etc/munge
-      - etc_slurm:/etc/slurm
       - slurm_jobdir:/data
       - var_log_slurm:/var/log/slurm
       - ./slurm.conf:/etc/slurm/slurm.conf
-      - ./slurmdbd.conf:/etc/slurm/slurmdbd.conf
     expose:
       - "6818"
     depends_on:
@@ -87,7 +79,6 @@ services:
 
 volumes:
   etc_munge:
-  etc_slurm:
   slurm_jobdir:
   var_lib_mysql:
   var_log_slurm:

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -e
+set -euo pipefail
 
 if [ "$1" = "slurmdbd" ]
 then
@@ -8,6 +8,8 @@ then
 
     echo "---> Starting the Slurm Database Daemon (slurmdbd) ..."
 
+    chown slurm:slurm /etc/slurm/slurmdbd.conf
+    chmod 600 /etc/slurm/slurmdbd.conf
     {
         . /etc/slurm/slurmdbd.conf
         until echo "SELECT 1" | mysql -h $StorageHost -u$StorageUser -p$StoragePass 2>&1 > /dev/null


### PR DESCRIPTION
- Removes etc_slurm named volume as unnecessary
- Mount slurm.conf and slurmdbd.conf in from host
- Note slurmdbd.conf has to be mounted in rw, then the entrypoint script chmods it to slurm inside the container.
- Tested that you can change slurm.conf on the host, then run `scontrol reconfigure` inside e.g. slurmctld, and changes are propagated to `slurmd`s