### PR TITLE
feat: allow dynamic change of the Slurm configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,3 +114,15 @@ docker-compose stop
 docker-compose rm -f
 docker volume rm slurm-docker-cluster_etc_munge slurm-docker-cluster_etc_slurm slurm-docker-cluster_slurm_jobdir slurm-docker-cluster_var_lib_mysql slurm-docker-cluster_var_log_slurm
 ```
+## Updating the Cluster
+
+If you want to change the `slurm.conf` or `slurmdbd.conf` file without a rebuilding you can do so by calling
+```console
+./update_slurmfiles.sh slurm.conf slurmdbd.conf
+```
+(or just one of the files).
+The Cluster will automatically be restarted afterwards with
+```console
+docker-compose restart
+```
+This might come in handy if you add or remove a node to your cluster or want to test a new setting.

--- a/update_slurmfiles.sh
+++ b/update_slurmfiles.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+set -e
+
+restart=false
+
+for var in "$@"
+do
+    if [ "$var" = "slurmdbd.conf" ] || [ "$var" = "slurm.conf" ]
+    then
+        export SLURM_TMP=$(cat $var)
+        docker exec slurmctld bash -c "echo \"$SLURM_TMP\" >/etc/slurm/\"$var\""
+        restart=true
+    fi
+done
+if $restart; then docker-compose restart; fi


### PR DESCRIPTION
Created a script that will inject a new configuration (slurm.conf or slurmdbd.conf) into the `etc_slurm` volume. 
This allows you to change settings or add new nodes to the cluster without rebuilding.

Thanks for this repo, love it and use it for a class on HPC so students can play around at home with a cluster.