### PR TITLE
Rearrange ARGS in Dockerfile to save build time

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,9 +6,6 @@ LABEL org.opencontainers.image.source="https://github.com/giovtorres/slurm-docke
       org.label-schema.docker.cmd="docker-compose up -d" \
       maintainer="Giovanni Torres"
 
-ARG SLURM_TAG=slurm-21-08-6-1
-ARG GOSU_VERSION=1.11
-
 RUN set -ex \
     && yum makecache \
     && yum -y update \
@@ -42,6 +39,8 @@ RUN alternatives --set python /usr/bin/python3
 
 RUN pip3 install Cython nose
 
+ARG GOSU_VERSION=1.11
+
 RUN set -ex \
     && wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-amd64" \
     && wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-amd64.asc" \
@@ -51,6 +50,8 @@ RUN set -ex \
     && rm -rf "${GNUPGHOME}" /usr/local/bin/gosu.asc \
     && chmod +x /usr/local/bin/gosu \
     && gosu nobody true
+
+ARG SLURM_TAG=slurm-21-08-6-1
 
 RUN set -x \
     && git clone -b ${SLURM_TAG} --single-branch --depth=1 https://github.com/SchedMD/slurm.git \


### PR DESCRIPTION
If either of these args is changed, the entirety of the Dockerfile is re-executed.

By moving them closer to where they're used the intermediate layers will be cached and build times can improve.