### PR TITLE
feat: use .env for SLURM_TAG and IMAGE_TAG

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,6 @@
+# Slurm git repo tag. See https://github.com/SchedMD/slurm/tags
+SLURM_TAG=slurm-21-08-6-1
+
+# Image version used to tag the container at build time (Typically matches the
+# Slurm tag in semantic verison form)
+IMAGE_TAG=21.08.6

--- a/Dockerfile
+++ b/Dockerfile
@@ -51,7 +51,7 @@ RUN set -ex \
     && chmod +x /usr/local/bin/gosu \
     && gosu nobody true
 
-ARG SLURM_TAG=slurm-21-08-6-1
+ARG SLURM_TAG
 
 RUN set -x \
     && git clone -b ${SLURM_TAG} --single-branch --depth=1 https://github.com/SchedMD/slurm.git \

--- a/README.md
+++ b/README.md
@@ -38,22 +38,22 @@ This setup consists of the following containers:
 
 ## 🛠️  Building the Docker Image
 
-You can build the Slurm Docker image locally with:
+The version of the Slurm project and the Docker build process can be simplified
+by using a `.env` file, which will be automatically picked up by Docker Compose.
+
+Update the `SLURM_TAG` and `IMAGE_TAG` found in the `.env` file and build
+the image:
 
 ```bash
-docker build -t slurm-docker-cluster:21.08.6 .
+docker compose build
 ```
 
-Or, to build a different version of Slurm, specify the [Slurm Git tag](https://github.com/SchedMD/slurm/tags):
+Alternatively, you can build the Slurm Docker image locally by specifying the
+[SLURM_TAG](https://github.com/SchedMD/slurm/tags) as a build argument and
+tagging the container with a version ***(IMAGE_TAG)***:
 
 ```bash
-docker build --build-arg SLURM_TAG="slurm-22-05-1-1" -t slurm-docker-cluster:22.05.1 .
-```
-
-Alternatively, use `docker compose` to build the image:
-
-```bash
-SLURM_TAG=slurm-22-05-1-1 IMAGE_TAG=22.05.1 docker compose build
+docker build --build-arg SLURM_TAG="slurm-21-08-6-1" -t slurm-docker-cluster:21.08.6 .
 ```
 
 ## 🚀 Starting the Cluster
@@ -65,10 +65,11 @@ using Docker Compose:
 docker compose up -d
 ```
 
-To specify a specific version, specify the `IMAGE_TAG`:
+To specify a specific version and override what is configured in `.env`, specify
+the `IMAGE_TAG`:
 
 ```bash
-IMAGE_TAG=22.05.1 docker compose up -d
+IMAGE_TAG=21.08.6 docker compose up -d
 ```
 
 This will start up all containers in detached mode. You can monitor their status using:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,11 +12,11 @@ services:
       - var_lib_mysql:/var/lib/mysql
 
   slurmdbd:
-    image: slurm-docker-cluster:${IMAGE_TAG:-21.08}
+    image: slurm-docker-cluster:${IMAGE_TAG}
     build:
       context: .
       args:
-        SLURM_TAG: ${SLURM_TAG:-slurm-21-08-6-1}
+        SLURM_TAG: ${SLURM_TAG}
     command: ["slurmdbd"]
     container_name: slurmdbd
     hostname: slurmdbd
@@ -30,7 +30,7 @@ services:
       - mysql
 
   slurmctld:
-    image: slurm-docker-cluster:${IMAGE_TAG:-21.08}
+    image: slurm-docker-cluster:${IMAGE_TAG}
     command: ["slurmctld"]
     container_name: slurmctld
     hostname: slurmctld
@@ -45,7 +45,7 @@ services:
       - "slurmdbd"
 
   c1:
-    image: slurm-docker-cluster:${IMAGE_TAG:-21.08}
+    image: slurm-docker-cluster:${IMAGE_TAG}
     command: ["slurmd"]
     hostname: c1
     container_name: c1
@@ -60,7 +60,7 @@ services:
       - "slurmctld"
 
   c2:
-    image: slurm-docker-cluster:${IMAGE_TAG:-21.08}
+    image: slurm-docker-cluster:${IMAGE_TAG}
     command: ["slurmd"]
     hostname: c2
     container_name: c2


### PR DESCRIPTION
This change switches to using a `.env` file for managing the `SLURM_TAG` and `IMAGE_TAG` environment variables for convenience. The README has been updated on how to use it.