### PR TITLE
Fix: Update configurations for startup SLURM (tag:25.05.3)

### DIFF
--- a/.env
+++ b/.env
@@ -1,6 +1,6 @@
 # Slurm git repo tag. See https://github.com/SchedMD/slurm/tags
-SLURM_TAG=slurm-21-08-6-1
+SLURM_TAG=slurm-25-05-3-1
 
 # Image version used to tag the container at build time (Typically matches the
 # Slurm tag in semantic version form)
-IMAGE_TAG=21.08.6
+IMAGE_TAG=25.05.3

--- a/cgroup.conf
+++ b/cgroup.conf
@@ -1,0 +1,1 @@
+CgroupPlugin=cgroup/v1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,16 +9,16 @@ services:
       MYSQL_USER: slurm
       MYSQL_PASSWORD: password
     volumes:
-      - var_lib_mysql:/var/lib/mysql
+      - var_lib_mysql:/var_lib/mysql
     networks:
       - slurm-network
 
   slurmdbd:
-    image: slurm-docker-cluster:${IMAGE_TAG}
+    image: slurm-docker-cluster:${SLURM_VERSION:-25.05.3}
     build:
       context: .
       args:
-        SLURM_TAG: ${SLURM_TAG}
+        SLURM_TAG: ${SLURM_TAG:-slurm-25-05-3-1}
     command: ["slurmdbd"]
     container_name: slurmdbd
     hostname: slurmdbd
@@ -34,7 +34,11 @@ services:
       - slurm-network
 
   slurmctld:
-    image: slurm-docker-cluster:${IMAGE_TAG}
+    image: slurm-docker-cluster:${SLURM_VERSION:-25.05.3}
+    build:
+      context: .
+      args:
+        SLURM_TAG: ${SLURM_TAG:-slurm-25-05-3-1}
     command: ["slurmctld"]
     container_name: slurmctld
     hostname: slurmctld
@@ -43,6 +47,7 @@ services:
       - etc_slurm:/etc/slurm
       - slurm_jobdir:/data
       - var_log_slurm:/var/log/slurm
+      - ./cgroup.conf:/etc/slurm/cgroup.conf # <-- ADICIONADO AQUI
     expose:
       - "6817"
     depends_on:
@@ -51,7 +56,11 @@ services:
       - slurm-network
 
   c1:
-    image: slurm-docker-cluster:${IMAGE_TAG}
+    image: slurm-docker-cluster:${SLURM_VERSION:-25.05.3}
+    build:
+      context: .
+      args:
+        SLURM_TAG: ${SLURM_TAG:-slurm-25-05-3-1}
     command: ["slurmd"]
     hostname: c1
     container_name: c1
@@ -60,6 +69,7 @@ services:
       - etc_slurm:/etc/slurm
       - slurm_jobdir:/data
       - var_log_slurm:/var/log/slurm
+      - ./cgroup.conf:/etc/slurm/cgroup.conf # <-- ADICIONADO AQUI
     expose:
       - "6818"
     depends_on:
@@ -68,7 +78,11 @@ services:
       - slurm-network
 
   c2:
-    image: slurm-docker-cluster:${IMAGE_TAG}
+    image: slurm-docker-cluster:${SLURM_VERSION:-25.05.3}
+    build:
+      context: .
+      args:
+        SLURM_TAG: ${SLURM_TAG:-slurm-25-05-3-1}
     command: ["slurmd"]
     hostname: c2
     container_name: c2
@@ -77,6 +91,7 @@ services:
       - etc_slurm:/etc/slurm
       - slurm_jobdir:/data
       - var_log_slurm:/var/log/slurm
+      - ./cgroup.conf:/etc/slurm/cgroup.conf # <-- ADICIONADO AQUI
     expose:
       - "6818"
     depends_on:

--- a/slurm.conf
+++ b/slurm.conf
@@ -56,9 +56,9 @@ SchedulerType=sched/backfill
 #SchedulerAuth=
 #SchedulerPort=
 #SchedulerRootFilter=
-SelectType=select/cons_res
-SelectTypeParameters=CR_CPU_Memory
-FastSchedule=1
+SelectType=select/cons_tres  # <-- MODIFICAÇÃO 1: Atualizado para compatibilidade com TRES
+SelectTypeParameters=CR_Core_Memory
+#FastSchedule=1              # <-- MODIFICAÇÃO 2: Comentado por ser obsoleto
 #PriorityType=priority/multifactor
 #PriorityDecayHalfLife=14-0
 #PriorityUsageResetPeriod=14-0
@@ -88,7 +88,10 @@ AccountingStoragePort=6819
 #AccountingStorageUser=
 #
 # COMPUTE NODES
-NodeName=c[1-2] RealMemory=1000 State=UNKNOWN
+# MODIFICAÇÃO 3: Nós definidos explicitamente para robustez na rede Docker e contagem de CPUs
+NodeName=c1 NodeAddr=c1 CPUs=2 RealMemory=1000 State=UNKNOWN
+NodeName=c2 NodeAddr=c2 CPUs=2 RealMemory=1000 State=UNKNOWN
 #
 # PARTITIONS
-PartitionName=normal Default=yes Nodes=c[1-2] Priority=50 DefMemPerCPU=500 Shared=NO MaxNodes=2 MaxTime=5-00:00:00 DefaultTime=5-00:00:00 State=UP
+#PartitionName=normal Default=yes Nodes=c1,c2 Priority=50 DefMemPerCPU=500 Shared=NO MaxNodes=2 MaxTime=5-00:00:00 DefaultTime=5-00:00:00 State=UP
+PartitionName=normal Nodes=c1,c2 Default=YES MaxTime=INFINITE State=UP


### PR DESCRIPTION
Hello!

This PR fixes a series of cascading startup failures when trying to build and run a recent version of SLURM (e.g., 25.05.3). The containers `slurmctld`, `c1`, and `c2` would exit with a fatal error shortly after launch.

These changes have been tested on the following environment:

**Environment Details**
**OS**: Ubuntu 22.04.3 LTS (running on a VM)
**Docker Version**: 28.4.0, build d8eb465
**Docker Compose Version**: v2.39.2
**SLURM Version (Built)**: 25.05.3
**Virtual Machine Manager**: 5.0.0

**Summary of Changes**

The solution required modifying `docker-compose.yml` and `slurm.conf`, and adding a new `cgroup.conf` to address plugin, resource accounting, and container initialization issues.

**1. `docker-compose.yml`:**

- Added the `build` context to the `slurmctld`, `c1`, and `c2` services. This ensures build consistency, forcing all services to be built from the local Dockerfile instead of being incorrectly pulled from a remote registry.
- Added a volume mount for the new `./cgroup.conf` file to the `slurmctld`, `c1`, and `c2` services.


**2. `slurm.conf`:**

- Updated `SelectType` to `select/cons_tres` for compatibility with modern Trackable RESources (TRES) scheduling.
- Replaced the condensed node definition (`NodeName=c[1-2]`) with explicit definitions for each node, crucially adding `NodeAddr` and `CPUs`. This resolves service discovery issues and satisfies the `cons_tres` plugin's requirement for an explicit CPU count.

**3. `cgroup.conf`:**

- Created a new `cgroup.conf` file with the content `CgroupPlugin=cgroup/v1`. This resolves the `fatal: Unable to initialize cgroup plugin` error on the `slurmd` nodes, which was preventing them from starting.

**Testing and Verification Steps**

With these changes applied, the cluster can be successfully launched with the following sequence:

```bash
# 1. Build and start the cluster
docker-compose up -d --build

# 2. Wait for services to stabilize (e.g., 30-40 seconds)
sleep 40

# 3. Verify all 5 containers are running
docker ps

# 4. Manually sync the node state to resolve the initial 'unk' state
docker exec slurmctld scontrol update nodename=c[1-2] state=resume

# 5. Check cluster status
docker exec slurmctld sinfo