### PR TITLE
feat: software mgmt with lmod and spack

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,6 +16,14 @@ COMPOSE_PROJECT_NAME=slurm
 #   - Selecting version-specific configuration files
 SLURM_VERSION=25.11.4
 
+# Lmod version (https://github.com/TACC/Lmod/releases)
+LMOD_VERSION=9.1.2
+
+# Spack version (https://github.com/spack/spack/releases)
+# Spack is cloned at image build time into /usr/local/spack (baked into the image).
+# Installed packages and generated Lmod modules are stored in the spack_root volume (/opt/spack).
+SPACK_VERSION=v1.1.1
+
 # SlurmDB MySQL credentials
 # Default values shown below (suitable for local development/testing only)
 MYSQL_USER=slurm

--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,5 @@ docker-compose.override.yml
 rpmbuild/
 archive/
 .claude/
+*.md
+!README*md

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,8 @@
 
 ARG SLURM_VERSION
 ARG GOSU_VERSION=1.19
+ARG LMOD_VERSION=9.1.2
+ARG SPACK_VERSION=v1.1.1
 # BUILDER_BASE and RUNTIME_BASE overridden when GPU_ENABLE=true is set in .env
 ARG BUILDER_BASE=rockylinux/rockylinux:9
 ARG RUNTIME_BASE=rockylinux/rockylinux:9
@@ -118,7 +120,70 @@ RUN set -ex \
     && ls -lh /root/rpmbuild/RPMS/${RPM_ARCH}/
 
 # ============================================================================
-# Stage 3: Runtime image
+# Stage 3: Build Lmod from source
+# (hardcoded Rocky Linux 9 base — GPU CUDA images are not needed to build Lmod)
+# ============================================================================
+FROM rockylinux/rockylinux:9 AS lmod-builder
+
+ARG LMOD_VERSION
+
+RUN set -ex \
+    && dnf -y install dnf-plugins-core epel-release \
+    && dnf config-manager --set-enabled crb \
+    && dnf -y install \
+       bc \
+       gcc \
+       lua \
+       lua-devel \
+       lua-posix \
+       lua-filesystem \
+       tcl \
+       tcl-devel \
+       procps-ng \
+       python3 \
+       wget \
+    && dnf clean all \
+    && rm -rf /var/cache/dnf
+
+RUN set -ex \
+    && wget -O /tmp/Lmod-${LMOD_VERSION}.tar.gz \
+       https://github.com/TACC/Lmod/archive/refs/tags/${LMOD_VERSION}.tar.gz \
+    && tar -xzf /tmp/Lmod-${LMOD_VERSION}.tar.gz -C /tmp \
+    && cd /tmp/Lmod-${LMOD_VERSION} \
+    && ./configure --prefix=/usr/local \
+    && make install
+
+# ============================================================================
+# Stage 4: Clone Spack from source
+# (hardcoded Rocky Linux 9 — no GPU overhead needed for this stage)
+# ============================================================================
+FROM rockylinux/rockylinux:9 AS spack-builder
+
+ARG SPACK_VERSION
+
+RUN dnf -y install git gcc && dnf clean all
+
+RUN git clone --depth=1 --branch "${SPACK_VERSION}" \
+        https://github.com/spack/spack.git /usr/local/spack
+
+# Write site-level Spack config:
+# - modules.yaml: generate Lmod modulefiles using the system GCC as the core compiler
+# - config.yaml:  store installed packages and generated modules under /opt/spack (the named volume)
+# - packages.yaml: pin target to the base ISA (x86_64 or aarch64) so the module
+#                  path is predictable and matches the MODULEPATH baked into lmod.sh
+RUN set -ex \
+    && GCC_VER=$(gcc --version | head -1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1) \
+    && ARCH=$(uname -m) \
+    && mkdir -p /usr/local/spack/etc/spack \
+    && printf 'modules:\n  default:\n    enable:\n      - lmod\n    roots:\n      lmod: /opt/spack/modules\n    lmod:\n      core_compilers:\n        - gcc@%s\n' \
+         "${GCC_VER}" > /usr/local/spack/etc/spack/modules.yaml \
+    && printf 'config:\n  install_tree:\n    root: /opt/spack\n' \
+         > /usr/local/spack/etc/spack/config.yaml \
+    && printf 'packages:\n  all:\n    require:\n      - "target=%s"\n' \
+         "${ARCH}" > /usr/local/spack/etc/spack/packages.yaml
+
+# ============================================================================
+# Stage 5: Runtime image
 # ============================================================================
 FROM ${RUNTIME_BASE}
 
@@ -141,7 +206,13 @@ RUN set -ex \
        apptainer \
        bash-completion \
        bzip2 \
+       bzip2-devel \
+       file \
+       gcc \
+       gcc-c++ \
+       gcc-gfortran \
        gettext \
+       git \
        hdf5 \
        http-parser \
        hwloc \
@@ -150,18 +221,24 @@ RUN set -ex \
        libaec \
        libyaml \
        lua \
+       lua-posix \
+       lua-filesystem \
        lz4 \
+       make \
        mariadb \
        munge \
        numactl \
        openssh-server \
+       patch \
        perl \
        procps-ng \
        psmisc \
        python3.12 \
        readline \
+       tcl \
        vim-enhanced \
        wget \
+       xz \
        libjwt \
     && dnf clean all \
     && rm -rf /var/cache/dnf \
@@ -171,9 +248,28 @@ RUN set -ex \
     && sed -i 's/^#\?PermitRootLogin.*/PermitRootLogin prohibit-password/' /etc/ssh/sshd_config \
     && sed -i 's/^#\?PasswordAuthentication.*/PasswordAuthentication no/' /etc/ssh/sshd_config
 
-# Install gosu (built from source in stage 1)
+# Install gosu
 COPY --from=gosu-builder /go/bin/gosu /usr/local/bin/gosu
 RUN gosu --version && gosu nobody true
+
+# Install Lmod
+COPY --from=lmod-builder /usr/local/lmod /usr/local/lmod
+
+# Install Spack
+COPY --from=spack-builder /usr/local/spack /usr/local/spack
+
+# Configure Lmod system-wide and source Spack's shell integration.
+# MODULEPATH uses the base ISA arch (x86_64/aarch64 from uname -m) which matches
+# the target forced in packages.yaml, avoiding microarch mismatches (e.g. zen2).
+RUN ARCH=$(uname -m) \
+    && printf '%s\n' \
+      'source /usr/local/lmod/lmod/init/bash' \
+      'export SPACK_ROOT=/usr/local/spack' \
+      "export MODULEPATH=\"/opt/spack/modules/linux-rocky9-${ARCH}/Core:/opt/modulefiles\"" \
+      'source /usr/local/spack/share/spack/setup-env.sh' \
+      > /etc/profile.d/lmod.sh \
+    && chmod 644 /etc/profile.d/lmod.sh \
+    && mkdir -p /opt/modulefiles /opt/spack /opt/spack/modules
 
 COPY --from=builder /root/rpmbuild/RPMS/*/*.rpm /tmp/rpms/
 
@@ -248,6 +344,7 @@ RUN set -ex \
     && chmod 644 /etc/slurm/slurm.conf /etc/slurm/cgroup.conf \
     && chmod 600 /etc/slurm/slurmdbd.conf \
     && rm -rf /tmp/slurm-config
+
 COPY --chown=slurm:slurm --chmod=0600 examples /root/examples
 
 COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh

--- a/README.md
+++ b/README.md
@@ -21,14 +21,11 @@ docker tag giovtorres/slurm-docker-cluster:latest slurm-docker-cluster:25.11.4
 # Option B: Build from source
 make build
 
-# Start the cluster
+# Then, start the cluster
 make up
-make status             # verify nodes are idle
-make test               # run full test suite
-make help               # see all available commands
 ```
 
-**Supported Slurm versions:** 25.11.x, 25.05.x (last two Major.Minor releases)
+**Supported Slurm versions:** 25.11, 25.05
 
 **Supported architectures (auto-detected):** AMD64, ARM64
 
@@ -194,7 +191,36 @@ make test-gpu
 
 > **Note:** GPU testing is not included in CI (GitHub-hosted runners have no GPUs). Run `make test-gpu` manually on a host with an NVIDIA GPU and `nvidia-container-toolkit` installed.
 
+## 📦 Software Installation
+
+[Spack](https://spack.io) is included in the image and integrates with [Lmod](https://lmod.readthedocs.io) so installed packages appear immediately as modules. All nodes share the same Spack and module tree.
+
+```bash
+make shell
+
+spack install python@3.14
+module avail
+module load python/3.14.0
+python --version
+```
+
+Modules are also available in batch jobs without any extra setup:
+
+```bash
+sbatch --wrap="module load python/3.14.0 && python3 --version"
+```
+
+To add a custom modulefile outside of Spack, drop a `.lua` file into the `opt_modulefiles` volume — it appears immediately on all nodes without a restart:
+
+```bash
+docker exec slurmctld mkdir -p /opt/modulefiles/myapp
+docker cp myapp/1.0.lua slurmctld:/opt/modulefiles/myapp/1.0.lua
+module avail
+```
+
 ## 🔄 Cluster Management
+
+Run `make` to see all available commands. Common ones:
 
 ```bash
 make down     # Stop cluster (keeps data)
@@ -202,8 +228,6 @@ make clean    # Remove all containers and volumes
 make rebuild  # Clean, rebuild, and restart
 make logs     # View container logs
 ```
-
-> **Note:** If `ELASTICSEARCH_HOST` is set in `.env`, monitoring containers are automatically managed.
 
 ## 🐳 Docker Hub
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,6 +25,8 @@ services:
       context: .
       args:
         SLURM_VERSION: ${SLURM_VERSION:-25.11.4}
+        LMOD_VERSION: ${LMOD_VERSION:-9.1.2}
+        SPACK_VERSION: ${SPACK_VERSION:-v1.1.1}
         GPU_ENABLE: ${GPU_ENABLE:-false}
         BUILDER_BASE: ${BUILDER_BASE:-rockylinux/rockylinux:9}
         RUNTIME_BASE: ${RUNTIME_BASE:-rockylinux/rockylinux:9}
@@ -69,6 +71,8 @@ services:
       - etc_slurm:/etc/slurm:z
       - slurm_jobdir:/data:z
       - var_log_slurm:/var/log/slurm:z
+      - opt_modulefiles:/opt/modulefiles
+      - spack_root:/opt/spack
       - ${SSH_AUTHORIZED_KEYS:-/dev/null}:/tmp/authorized_keys_host:ro,z
     ports:
       - "${SSH_PORT:-3022}:22"
@@ -125,6 +129,8 @@ services:
       - slurm_jobdir:/data
       - var_log_slurm:/var/log/slurm
       - home_ood:/home/ood  # shared with OOD for job I/O
+      - opt_modulefiles:/opt/modulefiles
+      - spack_root:/opt/spack
     expose:
       - "6818"
     depends_on:
@@ -157,6 +163,8 @@ services:
       - slurm_jobdir:/data
       - var_log_slurm:/var/log/slurm
       - home_ood:/home/ood  # shared with OOD for job I/O
+      - opt_modulefiles:/opt/modulefiles
+      - spack_root:/opt/spack
     expose:
       - "6818"
     depends_on:
@@ -265,6 +273,8 @@ volumes:
   var_lib_mysql:
   var_log_slurm:
   home_ood:
+  opt_modulefiles:
+  spack_root:
   elasticsearch_data:
 
 networks:

--- a/test_cluster.sh
+++ b/test_cluster.sh
@@ -67,7 +67,7 @@ test_containers_running() {
     done
 
     # Check cpu-worker nodes dynamically
-    WORKER_COUNT=$(docker compose ps cpu-worker --format '{{.Names}}' 2>/dev/null | wc -l)
+    WORKER_COUNT=$(docker compose ps cpu-worker --format '{{.Names}}' 2>/dev/null | wc -l | tr -d ' ')
 
     if [ "$WORKER_COUNT" -gt 0 ]; then
         print_info "  ✓ $WORKER_COUNT worker node(s) running"
@@ -131,10 +131,10 @@ test_slurmctld_status() {
 test_compute_nodes() {
     print_test "Testing compute nodes availability..."
 
-    NODE_COUNT=$(docker exec slurmctld sinfo -N -h | wc -l)
+    NODE_COUNT=$(docker exec slurmctld sinfo -N -h | wc -l | tr -d ' ')
 
     # Count running cpu-worker nodes
-    EXPECTED_COUNT=$(docker compose ps cpu-worker --format '{{.Names}}' 2>/dev/null | wc -l)
+    EXPECTED_COUNT=$(docker compose ps cpu-worker --format '{{.Names}}' 2>/dev/null | wc -l | tr -d ' ')
 
     if [ "$NODE_COUNT" -eq "$EXPECTED_COUNT" ]; then
         print_pass "$NODE_COUNT compute node(s) are available (matches expected $EXPECTED_COUNT)"
@@ -297,20 +297,11 @@ test_job_accounting() {
 test_multi_node_job() {
     print_test "Testing multi-node job allocation..."
 
-    # Get current node count
-    NODE_COUNT=$(docker exec slurmctld sinfo -N -h | wc -l)
-
-    # Only run multi-node test if we have 2+ nodes
-    if [ "$NODE_COUNT" -lt 2 ]; then
-        print_info "  Skipping (only $NODE_COUNT node available)"
-        return 0
-    fi
-
     # Try to allocate 2 nodes
     JOB_OUTPUT=$(docker exec slurmctld bash -c "srun -N 2 hostname" 2>&1 || echo "FAILED")
 
     # Count non-empty lines in output (should be 2 hostnames)
-    OUTPUT_LINES=$(echo "$JOB_OUTPUT" | grep -v "^$" | wc -l)
+    OUTPUT_LINES=$(echo "$JOB_OUTPUT" | grep -v "^$" | wc -l | tr -d ' ')
 
     if [ "$OUTPUT_LINES" -eq 2 ]; then
         print_pass "Multi-node job executed on 2 nodes"
@@ -347,11 +338,11 @@ test_scale_up() {
     print_test "Testing dynamic scale-up..."
 
     # Get initial node count
-    INITIAL_COUNT=$(docker exec slurmctld sinfo -N -h | wc -l)
+    INITIAL_COUNT=$(docker exec slurmctld sinfo -N -h | wc -l | tr -d ' ')
     print_info "  Initial node count: $INITIAL_COUNT"
 
     # Get current worker count and scale up by 1
-    WORKER_COUNT=$(docker compose ps cpu-worker --format '{{.Names}}' 2>/dev/null | wc -l)
+    WORKER_COUNT=$(docker compose ps cpu-worker --format '{{.Names}}' 2>/dev/null | wc -l | tr -d ' ')
     TARGET=$((WORKER_COUNT + 1))
     print_info "  Scaling cpu-worker from $WORKER_COUNT to $TARGET"
 
@@ -360,14 +351,14 @@ test_scale_up() {
     # Poll until the new node appears in Slurm and is ready (max 60s)
     EXPECTED_COUNT=$((INITIAL_COUNT + 1))
     for i in $(seq 1 60); do
-        CURRENT_COUNT=$(docker exec slurmctld sinfo -N -h 2>/dev/null | wc -l)
+        CURRENT_COUNT=$(docker exec slurmctld sinfo -N -h 2>/dev/null | wc -l | tr -d ' ')
         if [ "$CURRENT_COUNT" -ge "$EXPECTED_COUNT" ]; then
             break
         fi
         sleep 1
     done
 
-    CURRENT_COUNT=$(docker exec slurmctld sinfo -N -h | wc -l)
+    CURRENT_COUNT=$(docker exec slurmctld sinfo -N -h | wc -l | tr -d ' ')
 
     if [ "$CURRENT_COUNT" -ne "$EXPECTED_COUNT" ]; then
         print_fail "Expected $EXPECTED_COUNT nodes after scale-up, found $CURRENT_COUNT"
@@ -400,13 +391,8 @@ test_scale_down() {
     print_test "Testing dynamic scale-down with stale node cleanup..."
 
     # Get current counts
-    CURRENT_NODE_COUNT=$(docker exec slurmctld sinfo -N -h | wc -l)
-    WORKER_COUNT=$(docker compose ps cpu-worker --format '{{.Names}}' 2>/dev/null | wc -l)
-
-    if [ "$WORKER_COUNT" -lt 2 ]; then
-        print_info "  Skipping (only $WORKER_COUNT worker, need at least 2 to scale down)"
-        return 0
-    fi
+    CURRENT_NODE_COUNT=$(docker exec slurmctld sinfo -N -h | wc -l | tr -d ' ')
+    WORKER_COUNT=$(docker compose ps cpu-worker --format '{{.Names}}' 2>/dev/null | wc -l | tr -d ' ')
 
     TARGET=$((WORKER_COUNT - 1))
     EXPECTED_COUNT=$((CURRENT_NODE_COUNT - 1))
@@ -416,7 +402,7 @@ test_scale_down() {
 
     # Wait for the extra container to stop
     for i in $(seq 1 15); do
-        LIVE=$(docker compose ps cpu-worker --format '{{.Names}}' 2>/dev/null | wc -l)
+        LIVE=$(docker compose ps cpu-worker --format '{{.Names}}' 2>/dev/null | wc -l | tr -d ' ')
         if [ "$LIVE" -le "$TARGET" ]; then
             break
         fi
@@ -438,7 +424,7 @@ test_scale_down() {
     fi
 
     # Verify node count decreased
-    FINAL_COUNT=$(docker exec slurmctld sinfo -N -h | wc -l)
+    FINAL_COUNT=$(docker exec slurmctld sinfo -N -h | wc -l | tr -d ' ')
 
     if [ "$FINAL_COUNT" -ne "$EXPECTED_COUNT" ]; then
         print_fail "Expected $EXPECTED_COUNT nodes after scale-down, found $FINAL_COUNT"
@@ -476,15 +462,6 @@ test_singularity_pull_image() {
 test_singularity_multi_node_job() {
     print_test "Testing Singularity multi-node job..."
 
-    # Get current node count
-    NODE_COUNT=$(docker exec slurmctld sinfo -N -h | wc -l)
-
-    # Only run multi-node test if we have 2+ nodes
-    if [ "$NODE_COUNT" -lt 2 ]; then
-        print_info "  Skipping (only $NODE_COUNT node available)"
-        return 0
-    fi
-
     # Check if alpine_3.22.2.sif exists, if not, pull it
     if ! docker exec slurmctld test -f alpine_3.22.2.sif >/dev/null 2>&1; then
         if ! docker exec slurmctld singularity pull docker://alpine:3.22.2 >/dev/null 2>&1; then
@@ -497,7 +474,7 @@ test_singularity_multi_node_job() {
     JOB_OUTPUT=$(docker exec slurmctld bash -c "srun -N 2 singularity exec alpine_3.22.2.sif /bin/sh -c 'cat /etc/alpine-release'" 2>&1 || echo "FAILED")
 
     # Count non-empty lines in output (should be 2 Alpine release lines)
-    OUTPUT_LINES=$(echo "$JOB_OUTPUT" | grep -v "^$" | wc -l)
+    OUTPUT_LINES=$(echo "$JOB_OUTPUT" | grep -v "^$" | wc -l | tr -d ' ')
 
     # Clean up the image
     docker exec slurmctld rm alpine_3.22.2.sif >/dev/null 2>&1 || true
@@ -529,7 +506,7 @@ test_get_jwt_token() {
         print_info "  JWT Token: ${JWT_TOKEN:0:50}..."
 
         # Validate JWT token format (should have 3 parts separated by dots)
-        DOT_COUNT=$(echo "$JWT_TOKEN" | grep -o '\.' | wc -l)
+        DOT_COUNT=$(echo "$JWT_TOKEN" | grep -o '\.' | wc -l | tr -d ' ')
 
         if [ "$DOT_COUNT" -eq 2 ]; then
             # Verify each part contains valid base64-like characters
@@ -700,6 +677,80 @@ test_rest_api_partitions() {
     fi
 }
 
+test_lmod() {
+    print_test "Testing Lmod module system..."
+
+    # Check version string appears in output (guards against silent eval-of-empty-string failures)
+    if ! docker exec slurmctld bash -l -c "module --version" 2>&1 | grep -q "Modules based on Lua"; then
+        print_fail "Lmod not available (module --version did not return expected version string)"
+        return 1
+    fi
+    print_info "  ✓ Lmod is installed"
+
+    if ! docker exec slurmctld bash -l -c "module avail" > /dev/null 2>&1; then
+        print_fail "module avail failed"
+        return 1
+    fi
+    print_info "  ✓ module avail works"
+
+    print_pass "Lmod module system is working"
+}
+
+test_spack() {
+    print_test "Testing Spack + Lmod integration..."
+
+    # Spack is baked into the image at /usr/local/spack (not cloned at runtime)
+    if ! docker exec slurmctld test -f /usr/local/spack/share/spack/setup-env.sh 2>/dev/null; then
+        print_fail "Spack not found at /usr/local/spack (image build issue?)"
+        return 1
+    fi
+    print_info "  ✓ Spack present in image"
+
+    # Verify setup-env.sh can be sourced and spack command works
+    if ! docker exec slurmctld bash -c "export SPACK_ROOT=/usr/local/spack && source /usr/local/spack/share/spack/setup-env.sh && spack --version" > /dev/null 2>&1; then
+        print_fail "Failed to source Spack environment"
+        return 1
+    fi
+    print_info "  ✓ Spack environment loads"
+
+    # Verify Lmod modules.yaml is configured
+    if ! docker exec slurmctld grep -q "lmod" /usr/local/spack/etc/spack/modules.yaml 2>/dev/null; then
+        print_fail "Spack Lmod module configuration missing"
+        return 1
+    fi
+    print_info "  ✓ Lmod integration configured"
+
+    # Verify MODULEPATH includes the Spack Core dir on first login (baked into lmod.sh at build time)
+    if ! docker exec slurmctld bash -l -c 'echo "$MODULEPATH"' 2>/dev/null | grep -q "/opt/spack/modules/"; then
+        print_fail "MODULEPATH does not include Spack module tree (check /etc/profile.d/lmod.sh)"
+        return 1
+    fi
+    print_info "  ✓ MODULEPATH includes Spack module tree"
+
+    # Install gmake via Spack and verify it can be loaded as an Lmod module.
+    # gmake has no dependencies so it builds quickly.
+    print_info "  Installing gmake via Spack (this may take a few minutes)..."
+    if ! docker exec slurmctld bash -l -c "spack install gmake" > /dev/null 2>&1; then
+        print_fail "spack install gmake failed"
+        return 1
+    fi
+    print_info "  ✓ spack install gmake succeeded"
+
+    if ! docker exec slurmctld bash -l -c "module --ignore_cache avail 2>&1 | grep -q gmake"; then
+        print_fail "gmake module not visible after spack install"
+        return 1
+    fi
+    print_info "  ✓ gmake module visible in module avail"
+
+    if ! docker exec slurmctld bash -l -c "module load \$(module --ignore_cache avail -t 2>&1 | grep gmake | head -1) && gmake --version" > /dev/null 2>&1; then
+        print_fail "module load gmake failed or gmake --version did not run"
+        return 1
+    fi
+    print_info "  ✓ gmake module loads and binary is executable"
+
+    print_pass "Spack + Lmod integration is ready"
+}
+
 # Main test execution
 main() {
     # Ensure .env exists - copy from .env.example if not present
@@ -737,17 +788,19 @@ main() {
     test_job_submission || true
     test_job_execution || true
     test_job_accounting || true
-    test_multi_node_job || true
     test_resource_limits || true
     test_scale_up || true
-    test_scale_down || true
-    test_python_version || true
+    test_multi_node_job || true
     test_singularity_pull_image || true
     test_singularity_multi_node_job || true
+    test_scale_down || true
+    test_python_version || true
     test_rest_api_nodes || true
     test_rest_api_partitions || true
     test_get_jwt_token || true
     test_validate_jwt_authentication || true
+    test_lmod || true
+    test_spack || true
 
     # Print summary
     echo ""


### PR DESCRIPTION
This change adds lmod and spack to the cluster image for environment module management. They are wired together so packages installed via Spack are immediately available as Lmod modules on all nodes.

There are two new named volumes, `spack_root` and `opt_modulefiles`, so that installs and custom modules are visible cluster-wide without a restart.

`LMOD_VERSION` and `SPACK_VERSION` are configurable via `.env`.