### PR TITLE
docker-compose: add init: true to slurm services

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,6 +32,7 @@ services:
         RUNTIME_BASE: ${RUNTIME_BASE:-rockylinux/rockylinux:9}
       cache_from:
         - slurm-docker-cluster:${SLURM_VERSION:-25.11.4}
+    init: true
     command: ["slurmdbd"]
     container_name: slurmdbd
     hostname: slurmdbd
@@ -58,6 +59,7 @@ services:
 
   slurmctld:
     image: slurm-docker-cluster:${SLURM_VERSION:-25.11.4}
+    init: true
     command: ["slurmctld"]
     container_name: slurmctld
     hostname: slurmctld
@@ -92,6 +94,7 @@ services:
 
   slurmrestd:
     image: slurm-docker-cluster:${SLURM_VERSION:-25.11.4}
+    init: true
     command: ["slurmrestd"]
     container_name: slurmrestd
     hostname: slurmrestd
@@ -118,6 +121,7 @@ services:
 
   cpu-worker:
     image: slurm-docker-cluster:${SLURM_VERSION:-25.11.4}
+    init: true
     command: ["slurmd-cpu"]
     working_dir: /data
     privileged: true
@@ -151,6 +155,7 @@ services:
   # Requires: GPU_ENABLE=true in .env and nvidia-container-toolkit installed on host
   gpu-worker:
     image: slurm-docker-cluster:${SLURM_VERSION:-25.11.4}
+    init: true
     command: ["slurmd-gpu"]
     working_dir: /data
     privileged: true


### PR DESCRIPTION
ray issue link: https://github.com/ray-project/ray/issues/62390

## Summary

Sets `init: true` on `slurmdbd`, `slurmctld`, `slurmrestd`, `cpu-worker`, and `gpu-worker` so each container runs an init process (tini) as PID 1.

## Why

Ray's CI wants to use `slurm-docker-cluster` for multi-node Ray-on-Slurm scenarios; this PR unblocks that. Without `init: true`, `slurmd` is PID 1 and does not handle `SIGCHLD`, so Ray daemons orphaned by `ray start --head` stay as zombies and `ray stop` reports `Stopped 0 out of N`. With tini as PID 1 (Docker's standard [`init: true`](https://docs.docker.com/engine/containers/multi-service_container/) behavior), zombies are reaped and teardown is clean.

```text
┃ Host Linux ┃ ─────────────────────────────────────────

  PID 1: systemd                         ✓ handles SIGCHLD
      │
      ├── raylet            ◀── reparented to PID 1
      ├── gcs_server        ◀── after `ray start --head`
      ├── ...               ◀── returns
      └── (user shell, etc.)
          └── ray start --head (already returned)


┃ Container (current, no init) ┃ ──────────────────────

  PID 1: slurmd                          ✗ no SIGCHLD handler
      │
      ├── raylet            ◀── reparented to PID 1
      ├── gcs_server        ◀── after `ray start --head`
      ├── ...               ◀── returns
      └── slurmstepd
          └── job script
              └── ray start --head (already returned)


┃ Container (this PR, init: true) ┃ ───────────────────

  PID 1: tini                            ✓ handles SIGCHLD
      │
      ├── raylet            ◀── reparented to PID 1
      ├── gcs_server        ◀── after `ray start --head`
      ├── ...               ◀── returns
      └── slurmd            (no longer PID 1)
          └── slurmstepd
              └── job script
                  └── ray start --head (already returned)


Then `ray stop` sends SIGTERM → daemons exit → kernel marks them
zombie and delivers SIGCHLD to their current parent (PID 1):

  systemd → reaps   ✓   → ray stop: "Stopped all N"
  slurmd  → ignores ✗   → daemons stay as Z → "Stopped 0 out of N"
  tini    → reaps   ✓   → ray stop: "Stopped all N"
```

No trade-off (tini is ~50 KB; slurmd runs identically as a child of tini); not a breaking change.

## Refs

- PID 1 / SIGCHLD root-cause writeup: https://github.com/ray-project/ray/pull/62591#issuecomment-4396615458
- Confirmation that `init: true` resolves it (with `slurm-docker-cluster` job log): https://github.com/ray-project/ray/pull/62591#issuecomment-4403602546
- Tracking comment on Ray side: https://github.com/ray-project/ray/issues/62390#issuecomment-4404310713

## Test plan

- [ ] `docker compose config` parses cleanly
- [ ] `docker compose up -d` brings the cluster up healthy
- [ ] `docker exec <slurmd-container> ps -p 1 -o comm=` shows `tini` instead of `slurmd`
- [ ] No `Z` entries from a job that orphans children