### PR TITLE
Fix for WSL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -62,3 +62,5 @@ CPU_WORKER_COUNT=2
 #GPU_WORKER_COUNT=1
 #BUILDER_BASE=nvidia/cuda:13.1.1-devel-rockylinux9
 #RUNTIME_BASE=nvidia/cuda:13.1.1-base-rockylinux9
+# Use to disable GPU autodetection on WSL
+#IS_WSL=true

--- a/Dockerfile
+++ b/Dockerfile
@@ -195,6 +195,7 @@ LABEL org.opencontainers.image.source="https://github.com/giovtorres/slurm-docke
 ARG SLURM_VERSION
 ARG TARGETARCH
 ARG GPU_ENABLE
+ARG IS_WSL
 
 # Enable CRB and EPEL repositories, then install runtime dependencies
 RUN set -ex \
@@ -333,8 +334,13 @@ RUN set -ex \
          cp /tmp/slurm-config/common/cgroup.conf /etc/slurm/cgroup.conf; \
        fi \
     && if [ "$GPU_ENABLE" = "true" ]; then \
-         echo "GPU support enabled, installing gres.conf"; \
-         cp /tmp/slurm-config/common/gres.conf /etc/slurm/gres.conf; \
+         if [ "$IS_WSL" = "true" ]; then \
+           echo "GPU support enabled for WSL, installing gres-wsl.conf"; \
+           cp /tmp/slurm-config/common/gres-wsl.conf /etc/slurm/gres.conf; \
+         else \
+           echo "GPU support enabled, installing gres.conf"; \
+           cp /tmp/slurm-config/common/gres.conf /etc/slurm/gres.conf; \
+         fi; \
          chown slurm:slurm /etc/slurm/gres.conf; \
          chmod 644 /etc/slurm/gres.conf; \
        else \

--- a/README.md
+++ b/README.md
@@ -280,6 +280,10 @@ docker buildx build --platform linux/arm64 \
   --load -t slurm-docker-cluster:25.05.7 .
 ```
 
+### Windows subsystem for Linux
+
+Slurm's NVIDIA GPU autodetection doesn't currently work in WSL. To workaround this issue set `IS_WSL=true` in `.env`. The docker images will need to be rebuilt after setting this.
+
 ## 📚 Documentation
 
 - **Commands:** Run `make help` for all available commands

--- a/config/common/gres-wsl.conf
+++ b/config/common/gres-wsl.conf
@@ -1,0 +1,10 @@
+# gres.conf - Generic Resource (GRES) configuration
+# Defines GPU resources available on compute nodes
+#
+# This file is only used when GPU_ENABLE=true in .env when using WSL
+# Dynamic GPU workers register with --conf "Gres=gpu:nvidia:N"
+# This entry validates the type name used during registration.
+
+AutoDetect=off
+Name=gpu Type=nvidia File=/dev/dxg
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,6 +30,7 @@ services:
         GPU_ENABLE: ${GPU_ENABLE:-false}
         BUILDER_BASE: ${BUILDER_BASE:-rockylinux/rockylinux:9}
         RUNTIME_BASE: ${RUNTIME_BASE:-rockylinux/rockylinux:9}
+        IS_WSL: ${IS_WSL:-false}
       cache_from:
         - slurm-docker-cluster:${SLURM_VERSION:-25.11.4}
     init: true

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -188,7 +188,7 @@ then
     echo "---> Dynamic GPU worker registering as: ${NODE_NAME}"
     echo "---> Starting slurmd in dynamic GPU registration mode (-Z)..."
 
-    GPU_COUNT=$(ls /dev/nvidia[0-9] 2>/dev/null | wc -l)
+    GPU_COUNT=$(nvidia-smi --query-gpu=count --format=csv,noheader | head -n1)
     exec /usr/sbin/slurmd -Z -Dvvv \
         --conf "Feature=gpu Gres=gpu:nvidia:${GPU_COUNT}"
 fi


### PR DESCRIPTION
WSL doesn't expose `/dev/nvidia0`, instead there's a single `/dev/dxg` device. Use `nvidia-smi` to query the number of GPUs instead.